### PR TITLE
Add PHP 8.5 support

### DIFF
--- a/.github/workflows/php-qa.yml
+++ b/.github/workflows/php-qa.yml
@@ -71,7 +71,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php-ver: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
+                php-ver: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
                 wp-ver: [ '5.*', '6.*' ]
                 dependency-versions: [ 'highest', 'lowest' ]
                 exclude:
@@ -86,6 +86,10 @@ jobs:
                     -   php-ver: '8.4'
                         wp-ver: '5.*'
                     -   php-ver: '8.4'
+                        dependency-versions: 'lowest'
+                    -   php-ver: '8.5'
+                        wp-ver: '5.*'
+                    -   php-ver: '8.5'
                         dependency-versions: 'lowest'
 
         steps:
@@ -134,7 +138,7 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                php-ver: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
+                php-ver: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
         steps:
 
             -   name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -31,12 +31,12 @@
         "source": "https://github.com/wecodemore/wordpress-early-hook"
     },
     "require": {
-        "php": ">=7.1 < 8.5"
+        "php": ">=7.1 <= 8.5"
     },
     "require-dev": {
         "roots/wordpress-no-content": ">=6.1.1",
         "roave/security-advisories": "dev-latest",
-        "inpsyde/php-coding-standards": "^1.0.0",
+        "inpsyde/php-coding-standards": "^2.0.2",
         "vimeo/psalm": "^4.30.0",
         "phpunit/phpunit": "^7.5.20 || ^9.6.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "require-dev": {
         "roots/wordpress-no-content": ">=6.1.1",
         "roave/security-advisories": "dev-latest",
-        "inpsyde/php-coding-standards": "^2.0.2",
+        "inpsyde/php-coding-standards": "^1.0.0",
         "vimeo/psalm": "^4.30.0",
         "phpunit/phpunit": "^7.5.20 || ^9.6.4"
     },

--- a/tests/integration/IntegrationTest.php
+++ b/tests/integration/IntegrationTest.php
@@ -93,7 +93,9 @@ class IntegrationTest extends TestCase
 
         $hookObj = new class ($filter, $action)
         {
+            /** @var callable */
             private $filter;
+            /** @var callable */
             private $action;
 
             /**

--- a/wordpress-early-hook.php
+++ b/wordpress-early-hook.php
@@ -76,7 +76,6 @@ namespace WeCodeMore\WpEarlyHook
 }
 
 namespace WeCodeMore {
-
     /**
      * @param string $hook
      * @param callable $callback


### PR DESCRIPTION
## Changes

Adds support for PHP 8.5

### Test
Add PHP 8.5 support

### Fixes coding standard errors/warnings
```
FILE: /Users/soeren.wrede/workspace/wordpress-early-hook/wordpress-early-hook.php
-------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
-------------------------------------------------------------------------------------------------------------------
 87 | WARNING | [x] Expected 0 blank lines before function; 1 found (Squiz.WhiteSpace.FunctionSpacing.BeforeFirst)
-------------------------------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
-------------------------------------------------------------------------------------------------------------------


FILE: /Users/soeren.wrede/workspace/wordpress-early-hook/tests/integration/IntegrationTest.php
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 2 ERRORS AFFECTING 2 LINES
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 96 | ERROR | Property class@anonymous::$filter does not have native type hint nor @var annotation for its value. (SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingAnyTypeHint)
 97 | ERROR | Property class@anonymous::$action does not have native type hint nor @var annotation for its value. (SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingAnyTypeHint)
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```